### PR TITLE
Each metadata entry in the stub now is a list instead of a comma separated list of strings

### DIFF
--- a/stub/matcher.go
+++ b/stub/matcher.go
@@ -75,10 +75,9 @@ func matchMetadata(ctx context.Context, stub *Stub) bool {
 
 func getStubMetadata(stub *Stub) (stubMetadata map[string][]string) {
 	stubMetadata = make(map[string][]string, 0)
-	for key, value := range stub.Request.Metadata {
-		parts := strings.Split(value, ",")
-		for _, part := range parts {
-			stubMetadata[key] = append(stubMetadata[key], strings.TrimSpace(part))
+	for key, values := range stub.Request.Metadata {
+		for _, value := range values {
+			stubMetadata[key] = append(stubMetadata[key], strings.TrimSpace(value))
 		}
 	}
 	return

--- a/stub/model.go
+++ b/stub/model.go
@@ -27,9 +27,9 @@ type Stub struct {
 }
 
 type StubRequest struct {
-	Match    string            `json:"match"`
-	Content  JsonString        `json:"content"`
-	Metadata map[string]string `json:"metadata"`
+	Match    string              `json:"match"`
+	Content  JsonString          `json:"content"`
+	Metadata map[string][]string `json:"metadata"`
 }
 
 func (s StubRequest) String() string {


### PR DESCRIPTION
Closes #5 